### PR TITLE
Return the pynisher exit code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,10 @@ slight variation of the above example:
     for t in range(5):
         obj = pynisher.enforce_limits(wall_time_in_s=2, capture_output=True)(my_function)
         result = obj(t)
-        print(result, obj.result, obj.exit_status, obj.wall_clock_time, obj.stdout, obj.stderr)
+        print(
+            result, obj.result, obj.exit_status, obj.wall_clock_time,
+            obj.stdout, obj.stderr, obj.exitcode,
+        )
 
 
 The object ```obj``` can be used as the original function. After calling it, it contains
@@ -82,6 +85,8 @@ is either zero (function returned properly) or one of the following exceptions:
     pynisher.AnythingException	    # Something else went wrong, e.g., your function received a signal and just died.
 
 Here, the above issue about the grace period becomes interesting. Without it, it is likely that
-a AnythingException is returned where a Cpu-/TimeoutException would be appropriate.
+a AnythingException is returned where a Cpu-/TimeoutException would be appropriate. The ``exitcode``
+is the exitcode returned by the subprocess, see `multiprocessing.Process.exitcode <https://docs
+.python.org/3/library/multiprocessing.html#multiprocessing.Process.exitcode>`_
 
 This repository is based on Stefan Falkner's https://github.com/sfalkner/pynisher.

--- a/pynisher/limit_function_call.py
+++ b/pynisher/limit_function_call.py
@@ -266,12 +266,10 @@ class enforce_limits(object):
                 except: # noqa
                     self.logger.debug("Something else went wrong, sorry.")
                 finally:
-                    subproc.join()  # Wait for the process to finish - necessary to get the exitcode
                     self2.resources_function = resource.getrusage(resource.RUSAGE_CHILDREN)
                     self2.resources_pynisher = resource.getrusage(resource.RUSAGE_SELF)
                     self2.wall_clock_time = time.time() - start
                     self2.exit_status = 5 if self2.exit_status is None else self2.exit_status
-                    self2.exitcode = subproc.exitcode
 
                     # recover stdout and stderr if requested
                     if self.capture_output:
@@ -284,6 +282,8 @@ class enforce_limits(object):
 
                     # don't leave zombies behind
                     subproc.join()
+                    # exitcode is only available after join
+                    self2.exitcode = subproc.exitcode
                 return (self2.result)
 
         return (function_wrapper(func))

--- a/pynisher/limit_function_call.py
+++ b/pynisher/limit_function_call.py
@@ -266,10 +266,12 @@ class enforce_limits(object):
                 except: # noqa
                     self.logger.debug("Something else went wrong, sorry.")
                 finally:
+                    subproc.join()  # Wait for the process to finish - necessary to get the exitcode
                     self2.resources_function = resource.getrusage(resource.RUSAGE_CHILDREN)
                     self2.resources_pynisher = resource.getrusage(resource.RUSAGE_SELF)
                     self2.wall_clock_time = time.time() - start
                     self2.exit_status = 5 if self2.exit_status is None else self2.exit_status
+                    self2.exitcode = subproc.exitcode
 
                     # recover stdout and stderr if requested
                     if self.capture_output:

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -366,5 +366,6 @@ class test_limit_resources_module(unittest.TestCase):
             self.assertEqual(wrapped_function.os_errno, 12)
         self.assertEqual(wrapped_function.exitcode, 0)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -315,7 +315,6 @@ class test_limit_resources_module(unittest.TestCase):
         self.assertEqual(wrapped_function.stderr, '')
         self.assertEqual(wrapped_function.exitcode, 0)
 
-
         def print_and_fail():
             print(0)
             raise RuntimeError()
@@ -329,7 +328,6 @@ class test_limit_resources_module(unittest.TestCase):
         self.assertIn('0', wrapped_function.stdout)
         self.assertIn('RuntimeError', wrapped_function.stderr)
         self.assertEqual(wrapped_function.exitcode, 1)
-
 
     def test_too_little_memory(self):
         # Test what happens if the target process does not have a sufficiently high memory limit
@@ -352,7 +350,6 @@ class test_limit_resources_module(unittest.TestCase):
             self.assertEqual(wrapped_function.os_errno, 12)
         self.assertEqual(wrapped_function.exitcode, 0)
 
-
     def test_raise(self):
         # As above test does not reliably work on travis-ci, this test checks whether an
         # OSError's error code is properly read out
@@ -368,8 +365,6 @@ class test_limit_resources_module(unittest.TestCase):
         if wrapped_function.exit_status == pynisher.SubprocessException:
             self.assertEqual(wrapped_function.os_errno, 12)
         self.assertEqual(wrapped_function.exitcode, 0)
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -130,6 +130,7 @@ class test_limit_resources_module(unittest.TestCase):
         for mem in [1, 2, 4, 8, 16]:
             self.assertEqual((mem, 0, 0), wrapped_function(mem, 0, 0))
             self.assertEqual(wrapped_function.exit_status, 0)
+            self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping out_of_memory test")
     def test_out_of_memory(self):
@@ -146,6 +147,7 @@ class test_limit_resources_module(unittest.TestCase):
         for mem in [1024, 2048, 4096]:
             self.assertIsNone(wrapped_function(mem, 0, 0))
             self.assertEqual(wrapped_function.exit_status, pynisher.MemorylimitException)
+            self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping time_out test")
     def test_time_out(self):
@@ -162,6 +164,7 @@ class test_limit_resources_module(unittest.TestCase):
         for mem in range(1, 10):
             self.assertIsNone(wrapped_function(mem, 10, 0))
             self.assertEqual(wrapped_function.exit_status, pynisher.TimeoutException, str(wrapped_function.result))
+            self.assertEqual(wrapped_function.exitcode, -15)
 
     @unittest.skipIf(not all_tests, "skipping too many processes test")
     def test_num_processes(self):
@@ -178,6 +181,7 @@ class test_limit_resources_module(unittest.TestCase):
         for processes in [2, 15, 50, 100, 250]:
             self.assertIsNone(wrapped_function(0, 0, processes))
             self.assertEqual(wrapped_function.exit_status, pynisher.SubprocessException)
+            self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping unexpected signal test")
     def test_crash_unexpectedly(self):
@@ -185,6 +189,7 @@ class test_limit_resources_module(unittest.TestCase):
         wrapped_function = pynisher.enforce_limits()(crash_unexpectedly)
         self.assertIsNone(wrapped_function(signal.SIGQUIT))
         self.assertEqual(wrapped_function.exit_status, pynisher.SignalException)
+        self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping unexpected signal test")
     def test_high_cpu_percentage(self):
@@ -196,6 +201,7 @@ class test_limit_resources_module(unittest.TestCase):
 
         self.assertEqual(None, wrapped_function())
         self.assertEqual(wrapped_function.exit_status, pynisher.CpuTimeoutException)
+        self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping big data test")
     def test_big_return_data(self):
@@ -205,6 +211,7 @@ class test_limit_resources_module(unittest.TestCase):
         for num_elements in [4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144]:
             bla = wrapped_function(num_elements)
             self.assertEqual(len(bla), num_elements)
+            self.assertEqual(wrapped_function.exitcode, 0)
 
     @unittest.skipIf(not all_tests, "skipping subprocess changing process group")
     def test_kill_subprocesses(self):
@@ -214,6 +221,7 @@ class test_limit_resources_module(unittest.TestCase):
         time.sleep(1)
         p = psutil.Process()
         self.assertEqual(len(p.children(recursive=True)), 0)
+        self.assertEqual(wrapped_function.exitcode, -15)
 
     @unittest.skipIf(not is_sklearn_available, "test requires scikit learn")
     @unittest.skipIf(not all_tests, "skipping fitting an SVM to see how C libraries are handles")
@@ -231,6 +239,7 @@ class test_limit_resources_module(unittest.TestCase):
         p = psutil.Process()
         self.assertEqual(len(p.children(recursive=True)), 0)
         self.assertTrue(duration < 2.1)
+        self.assertEqual(wrapped_function.exitcode, -15)
 
     @unittest.skipIf(not is_sklearn_available, "test requires scikit learn")
     @unittest.skipIf(not all_tests, "skipping fitting an SVM to see how C libraries are handles")
@@ -262,6 +271,7 @@ class test_limit_resources_module(unittest.TestCase):
         # self.assertEqual(wrapped_function.exit_status, pynisher.CpuTimeoutException)
         self.assertGreater(duration, time_limit - 0.1)
         self.assertLess(duration, time_limit + grace_period + 0.1)
+        self.assertEqual(wrapped_function.exitcode, -9)
 
     @unittest.skipIf(not all_tests, "skipping nested pynisher test")
     def test_nesting(self):
@@ -301,6 +311,7 @@ class test_limit_resources_module(unittest.TestCase):
 
         self.assertTrue('0' in wrapped_function.stdout)
         self.assertTrue(wrapped_function.stderr == '')
+        self.assertEqual(wrapped_function.exitcode, 0)
 
         def print_and_fail():
             print(0)
@@ -314,6 +325,7 @@ class test_limit_resources_module(unittest.TestCase):
 
         self.assertTrue('0' in wrapped_function.stdout)
         self.assertTrue('RuntimeError' in wrapped_function.stderr)
+        self.assertEqual(wrapped_function.exitcode, 1)
 
     def test_too_little_memory(self):
         # Test what happens if the target process does not have a sufficiently high memory limit
@@ -334,6 +346,7 @@ class test_limit_resources_module(unittest.TestCase):
         # This is triggered on my local machine, but not on travis-ci
         if wrapped_function.exit_status == pynisher.SubprocessException:
             self.assertEqual(wrapped_function.os_errno, 12)
+        self.assertEqual(wrapped_function.exitcode, 0)
 
     def test_raise(self):
         # As above test does not reliably work on travis-ci, this test checks whether an
@@ -349,6 +362,7 @@ class test_limit_resources_module(unittest.TestCase):
         self.assertEqual(wrapped_function.exit_status, pynisher.SubprocessException)
         if wrapped_function.exit_status == pynisher.SubprocessException:
             self.assertEqual(wrapped_function.os_errno, 12)
+        self.assertEqual(wrapped_function.exitcode, 0)
 
 
 if __name__ == '__main__':

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -164,7 +164,8 @@ class test_limit_resources_module(unittest.TestCase):
         for mem in range(1, 10):
             self.assertIsNone(wrapped_function(mem, 10, 0))
             self.assertEqual(wrapped_function.exit_status, pynisher.TimeoutException, str(wrapped_function.result))
-            self.assertEqual(wrapped_function.exitcode, -15)
+            # Apparently, the exit code here is not deterministic (so far only PYthon 3.6)
+            self.assertIn(wrapped_function.exitcode, (-15, 0))
 
     @unittest.skipIf(not all_tests, "skipping too many processes test")
     def test_num_processes(self):


### PR DESCRIPTION
To allow better debugging. I don't know whether the `subproc.join()` without a timeout is a good idea, but it didn't make any problems with the unit tests.