### PR TITLE
Fix context: use context if passed

### DIFF
--- a/pynisher/limit_function_call.py
+++ b/pynisher/limit_function_call.py
@@ -171,7 +171,7 @@ class enforce_limits(object):
         if context is None:
             self.context = multiprocessing.get_context()
         else:
-            self.context = multiprocessing
+            self.context = context
 
         self.mem_in_mb = mem_in_mb
         self.cpu_time_in_s = cpu_time_in_s

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pynisher',
-    version="0.6.2",
+    version="0.6.3",
     packages=['pynisher'],
     install_requires=['docutils>=0.3', 'setuptools', 'psutil'],
     author="Stefan Falkner, Christina Hernandez-Wunsch, Samuel Mueller and Matthias Feurer",


### PR DESCRIPTION
CC @LMZimmer that's what my previous PR should have done - use the context if passed. This now allows the use of custom multiprocessing contexts.