### PR TITLE
Robust stdout reading

### DIFF
--- a/pynisher/limit_function_call.py
+++ b/pynisher/limit_function_call.py
@@ -285,17 +285,19 @@ class enforce_limits(object):
                     # recover stdout and stderr if requested
                     if self.capture_output:
                         out_file = os.path.join(tmp_dir.name, 'std.out')
-                        if os.path.exists(out_file):
+                        try:
                             with open(out_file, 'r') as fh:
                                 self2.stdout = fh.read()
-                        else:
-                            self.logger.error(f"Cannot find {out_file}")
+                        except Exception as e:
+                            self.logger.error(
+                                f"Cannot recover the output from {out_file} due to {e}")
                         err_file = os.path.join(tmp_dir.name, 'std.err')
-                        if os.path.exists(err_file):
+                        try:
                             with open(os.path.join(tmp_dir.name, 'std.err'), 'r') as fh:
                                 self2.stderr = fh.read()
-                        else:
-                            self.logger.error(f"Cannot find file {err_file}")
+                        except Exception as e:
+                            self.logger.error(
+                                f"Cannot recover the output from {err_file} due to {e}")
 
                         tmp_dir.cleanup()
 

--- a/pynisher/limit_function_call.py
+++ b/pynisher/limit_function_call.py
@@ -284,10 +284,18 @@ class enforce_limits(object):
 
                     # recover stdout and stderr if requested
                     if self.capture_output:
-                        with open(os.path.join(tmp_dir.name, 'std.out'), 'r') as fh:
-                            self2.stdout = fh.read()
-                        with open(os.path.join(tmp_dir.name, 'std.err'), 'r') as fh:
-                            self2.stderr = fh.read()
+                        out_file = os.path.join(tmp_dir.name, 'std.out')
+                        if os.path.exists(out_file):
+                            with open(out_file, 'r') as fh:
+                                self2.stdout = fh.read()
+                        else:
+                            self.logger.error(f"Cannot find {out_file}")
+                        err_file = os.path.join(tmp_dir.name, 'std.err')
+                        if os.path.exists(err_file):
+                            with open(os.path.join(tmp_dir.name, 'std.err'), 'r') as fh:
+                                self2.stderr = fh.read()
+                        else:
+                            self.logger.error(f"Cannot find file {err_file}")
 
                         tmp_dir.cleanup()
 

--- a/test/test_pynisher.py
+++ b/test/test_pynisher.py
@@ -497,7 +497,7 @@ class test_limit_resources_module(unittest.TestCase):
             logger=logger_mock,
             capture_output=True
         )(print_and_sleep)
-        wrapped_function(5)
+        return_value = wrapped_function(5)
 
         # On failure, the log file will catch the error msg
         self.assertIn('Cannot recover the output from', str(logger_mock.error.call_args))
@@ -505,6 +505,10 @@ class test_limit_resources_module(unittest.TestCase):
         # And the stdout/stderr attributes will be left as None
         self.assertIsNone(wrapped_function.stdout)
         self.assertIsNone(wrapped_function.stderr)
+
+        # Also check the return value
+        self.assertEqual(wrapped_function.exit_status, 5)
+        self.assertIsNone(return_value)
 
 
 if __name__ == '__main__':

--- a/test/test_pynisher.py
+++ b/test/test_pynisher.py
@@ -479,6 +479,33 @@ class test_limit_resources_module(unittest.TestCase):
             self.assertEqual(wrapped_function.os_errno, 2)
         self.assertEqual(wrapped_function.exitcode, 0)
 
+    def test_capture_output_error(self):
+        grace_period = 1
+
+        # We want to mimic an scenario where the context.Pipe
+        # fails early, so that a stdout file was not created.
+        context = unittest.mock.Mock()
+        logger_mock = unittest.mock.Mock()
+        context.Pipe.return_value = (unittest.mock.Mock(), unittest.mock.Mock())
+        context.Pipe.return_value[0]._side_effect = ValueError()
+
+        wrapped_function = pynisher.enforce_limits(
+            wall_time_in_s=1,
+            mem_in_mb=None,
+            context=context,
+            grace_period_in_s=grace_period,
+            logger=logger_mock,
+            capture_output=True
+        )(print_and_sleep)
+        wrapped_function(5)
+
+        # On failure, the log file will catch the error msg
+        self.assertIn('Cannot recover the output from', str(logger_mock.error.call_args))
+
+        # And the stdout/stderr attributes will be left as None
+        self.assertIsNone(wrapped_function.stdout)
+        self.assertIsNone(wrapped_function.stderr)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
During autopytorch development, we see the 
```
No such file or directory...stdout.out
```

In our case, was because we did not provide enough time to the algorithm execution. It should have ended as a timeout. Does it makes sense to query for this file and error if it is not there rather than crashing the run?