### PR TITLE
Added cron job

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Every Monday at 7AM UTC
+    - cron: '0 07 * * 5'
 
 jobs:
   ubuntu:
@@ -35,6 +40,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
+      # A not on checkout: When checking out the repository that
+      # triggered a workflow, this defaults to the reference or SHA for that event.
+      # Otherwise, uses the default branch (master) is used.
       with:
         python-version: ${{ matrix.python-version }}
     - name: Conda Install test dependencies 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ if sys.version_info < (3, 6):
     )
 
 
-
 HERE = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(HERE, 'requirements.txt')) as fp:
     install_reqs = [r.rstrip() for r in fp.readlines()


### PR DESCRIPTION
Enables a weekly cron job to make sure the master branch is working (mainly to catch external package dependencies errors).

