### PR TITLE
[fix] Unit test failures -- out of memory and pre-commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ if sys.version_info < (3, 6):
     )
 
 
-
 HERE = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(HERE, 'requirements.txt')) as fp:
     install_reqs = [r.rstrip() for r in fp.readlines()

--- a/test/test_pynisher.py
+++ b/test/test_pynisher.py
@@ -199,7 +199,7 @@ class test_limit_resources_module(unittest.TestCase):
             grace_period_in_s=local_grace_period)(simulate_work)
 
         for mem in [1024, 2048, 4096]:
-            returned_object = (wrapped_function(mem, 0, 0)
+            returned_object = wrapped_function(mem, 0, 0)
             self.assertIsNone(returned_object, f"returned_object={returned_object}/{vars(wrapped_function)}")
             self.assertEqual(wrapped_function.exit_status, pynisher.MemorylimitException)
             # In github actions, randomly on python 3.6 and 3.9, the exit

--- a/test/test_pynisher.py
+++ b/test/test_pynisher.py
@@ -199,7 +199,8 @@ class test_limit_resources_module(unittest.TestCase):
             grace_period_in_s=local_grace_period)(simulate_work)
 
         for mem in [1024, 2048, 4096]:
-            self.assertIsNone(wrapped_function(mem, 0, 0))
+            returned_object = (wrapped_function(mem, 0, 0)
+            self.assertIsNone(returned_object, f"returned_object={returned_object}/{vars(wrapped_function)}")
             self.assertEqual(wrapped_function.exit_status, pynisher.MemorylimitException)
             # In github actions, randomly on python 3.6 and 3.9, the exit
             # status is 1 that happens while running ppid_map during a MemoryError


### PR DESCRIPTION
There is a bug in flake 8, which is being corrected by this PR.

Also, I constantly see memory-out test failing in python 3.9. I am proposing to move this test to pytest so that each memory-limit is parametrized. This seems to work in my branch (probably because each parametrized memory limit is run a different forked process). 